### PR TITLE
Add WinGet Releaser

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,15 @@
+name: Publish to WinGet
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal2009/vedantmgoyal2009/winget-pkgs-automation/releaser-action@v1.0.0
+        with:
+          identifier: Xanthus58.ValorantRandomizer
+          installers-regex: '\.exe$'
+          delete-previous-version: 'true'
+          token: ${{ secrets.WINGET_TOKEN }} 


### PR DESCRIPTION
This pull request adds a workflow that automatically publishes Valorant Randomizer to WinGet every release, as discussed in #2. *Please do not merge this pull request without reading the below and making the required changes* (The token part is the important bit) :)

- `runs-on: windows-latest`

The WinGet Releaser action can only run on Windows.

</br>

- `identifier: Xanthus58.ValorantRandomizer`

This is the identifier for Valorant Randomizer on Winget. It will use this to find ValorantRandomizer's current package on WinGet.

</br>

- `installers-regex: '\.exe$'`

This will make all `.exe` files in the assets of the latest Valorant Randomizer release to be included in the pull request (Only one exe must be present in the assets as that is what is currently on WinGet - if you ever wanted to provide more installers, a bit of manual intervention would be required).

</br>

- `delete-previous-version: 'true'`

This is optional, and you are welcome to change this to false (or omit it; the default is false). This will essentially overwrite the previous version on WinGet packages, so that only this new version is stored on WinGet.

</br>

- `token: ${{ secrets.WINGET_TOKEN }}`

This is the bit that will require action from yourself. This is a GitHub token with which the action will authenticate with GitHub and create a pull request on the [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository.

To do this, you will need to:

1. Create a Personal Access Token (PAT) with `public_repo` scope on your GitHub account.
![image](https://user-images.githubusercontent.com/74878137/170548538-0d689177-5c9e-4bb2-8a87-e09eb5ca64e8.png)

2. Create a repository secret containing the token. **Super important: call this token: `WINGET_TOKEN`**.
See [using encrypted secrets in a workflow](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow) for more details.

</br>

**Finally, make sure you have a fork of [winget-pkgs](https://github.com/microsoft/winget-pkgs) on your GitHub account. Please do not delete the fork after a pull request has been merged as the action will use that fork for making a branch and merging it with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every Valorant Randomizer release.**

The above is made on the assumption that the account that the token is from (and the fork is present) is @Xanthus58. If you would like this to be done by another account, the token would have to be from the different user and an extra line would have to be added: `fork-user: # Username of other user` (this defaults to the repository owner, which is why it doesn't have to be added)

If you would like to read about this action further, the documentation is [here](https://bittu.eu.org/docs/wr-intro) and the source code is [here](https://github.com/vedantmgoyal2009/vedantmgoyal2009/blob/main/winget-pkgs-automation/releaser-action/action.yml).

If you are interested in what a pull request made by this action looks like, here is one from my account: [#61982 on winget-pkgs](https://github.com/microsoft/winget-pkgs/pull/61469).